### PR TITLE
Add `clone`

### DIFF
--- a/src/Control/Monad/Eff/JQuery.js
+++ b/src/Control/Monad/Eff/JQuery.js
@@ -297,3 +297,16 @@ exports.getMetaKey = function(e) {
         return jQuery(e.metaKey);
     };
 };
+
+
+exports.clone = function(ob) {
+    return function() {
+        return ob.clone();
+    };
+};
+
+exports.cloneWithDataAndEvents = function(ob) {
+    return function() {
+        return ob.clone(true);
+    };
+};

--- a/src/Control/Monad/Eff/JQuery.purs
+++ b/src/Control/Monad/Eff/JQuery.purs
@@ -300,3 +300,16 @@ foreign import getMetaKey
   :: forall eff
    . JQueryEvent
   -> Eff (dom :: DOM | eff) Boolean
+
+-- | Create a deep copy of the set of matched elements.
+foreign import clone
+  :: forall eff
+   . JQuery
+  -> Eff (dom :: DOM | eff) JQuery
+
+-- | Create a deep copy of the set of matched elements,
+-- | including event handlers and element data.
+foreign import cloneWithDataAndEvents
+  :: forall eff
+   . JQuery
+  -> Eff (dom :: DOM | eff) JQuery


### PR DESCRIPTION
This adds basic support for `jQuery.clone`. The `jQuery.clone` method accepts an optional second parameter `deepWithDataAndEvents`, not currently implemented. I'm open to suggestions how to handle that on the PureScript side.