### PR TITLE
Update the ffi for getPageX, getPageY, getMetaKey, getWhich

### DIFF
--- a/src/Control/Monad/Eff/JQuery.js
+++ b/src/Control/Monad/Eff/JQuery.js
@@ -300,25 +300,25 @@ exports.getCurrentTarget = function(e) {
 
 exports.getPageX = function(e) {
     return function() {
-        return jQuery(e.pageX);
+        return e.pageX;
     };
 };
 
 exports.getPageY = function(e) {
     return function() {
-        return jQuery(e.pageY);
+        return e.pageY;
     };
 };
 
 exports.getWhich = function(e) {
     return function() {
-        return jQuery(e.which);
+        return e.which;
     };
 };
 
 exports.getMetaKey = function(e) {
     return function() {
-        return jQuery(e.metaKey);
+        return e.metaKey;
     };
 };
 


### PR DESCRIPTION
It looks like the ffi for getPageX, getPageY, getMetaKey, getWhich are returning jQuery objects right now, but the purescript signatures say they return Number, Number, Int, and Boolean respectively.

![image](https://user-images.githubusercontent.com/1159795/27596766-c369a080-5b1d-11e7-8a94-2dc725240406.png)