### PR TITLE
Prevent HTML parsing in appendText

### DIFF
--- a/src/Control/Monad/Eff/JQuery.js
+++ b/src/Control/Monad/Eff/JQuery.js
@@ -130,7 +130,7 @@ exports.append = function(ob1) {
 exports.appendText = function(s) {
     return function(ob) {
         return function() {
-            ob.append(s);
+            ob.append(document.createTextNode(s));
         };
     };
 };

--- a/src/Control/Monad/Eff/JQuery.js
+++ b/src/Control/Monad/Eff/JQuery.js
@@ -127,6 +127,14 @@ exports.append = function(ob1) {
     };
 };
 
+exports.unsafeAppendHtml = function(s) {
+    return function(ob) {
+        return function() {
+            ob.append(s);
+        };
+    };
+};
+
 exports.appendText = function(s) {
     return function(ob) {
         return function() {

--- a/src/Control/Monad/Eff/JQuery.purs
+++ b/src/Control/Monad/Eff/JQuery.purs
@@ -220,6 +220,14 @@ foreign import before
    . JQuery
   -> JQuery -> Eff (dom :: DOM | eff) Unit
 
+-- | Append text as a child node. Importantly, if jQuery recognises the String
+-- | as HTML, the parsed HTML will be appended, rather than the string. Hence,
+-- | this function can be dangerous when dealing with unchecked user input.
+foreign import unsafeAppendHtml
+  :: forall eff
+   . String
+  -> JQuery -> Eff (dom :: DOM | eff) Unit
+
 -- | Append text as a child node.
 foreign import appendText
   :: forall eff


### PR DESCRIPTION
Currently, if you pass an HTML-looking string to `appendText`, the text will be parsed as HTML. This was a problem for TryPureScript, as the errors were rendered using this function. Thus, if you put HTML in a type error, it would be executed, which led to this fantastic moment:

https://gist.github.com/i-am-tom/cc552efe2f82c7c42d63c6b0ec69e614

This commit uses `document.createTextNode` to prevent this from happening, which essentially does a pauper's HTML escape, as per this StackOverflow answer: https://stackoverflow.com/a/944456

This means we can revert [@paf31's commit to TryPureScript](https://github.com/purescript/trypurescript/commit/4a235011c3ec54b266e3d0cce67cf31a0fd3acd4), too, and forget this ever happened ^_^

_Also, cc @liamgoodacre who actually suggested going to look at the binding. I am still very much incapable of original thought._