### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/JQuery.js
+++ b/src/JQuery.js
@@ -246,7 +246,7 @@ exports.on = function(evt) {
     };
 };
 
-exports["on'"] = function(evt) {
+exports.delegate = function(evt) {
     return function(sel) {
         return function(act) {
             return function(ob) {
@@ -270,7 +270,7 @@ exports.off = function(evt) {
 };
 
 
-exports["off'"] = function(ob) {
+exports.deafen = function(ob) {
     return function() {
         return ob.off();
     };

--- a/src/JQuery.purs
+++ b/src/JQuery.purs
@@ -190,13 +190,19 @@ display = setVisible true
 foreign import on :: forall a. String -> (JQueryEvent -> JQuery -> Effect a) -> JQuery -> Effect Unit
 
 -- | Register an event handler for elements matching a selector.
-foreign import on':: forall a. String -> Selector -> (JQueryEvent -> JQuery -> Effect a) -> JQuery -> Effect Unit
+foreign import delegate :: forall a. String -> Selector -> (JQueryEvent -> JQuery -> Effect a) -> JQuery -> Effect Unit
+
+on':: forall a. String -> Selector -> (JQueryEvent -> JQuery -> Effect a) -> JQuery -> Effect Unit
+on' = delegate
 
 -- | Remove an event handler.
 foreign import off :: String -> JQuery -> Effect Unit
 
 -- | Remove all event handler.
-foreign import off':: JQuery -> Effect Unit
+foreign import deafen :: JQuery -> Effect Unit
+
+off':: JQuery -> Effect Unit
+off' = deafen
 
 -- | Get an array of matching elements.
 foreign import toArray :: JQuery -> Effect (Array JQuery)


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.